### PR TITLE
No more ICE with the latest OS X clang, apparently.

### DIFF
--- a/core/emu.cpp
+++ b/core/emu.cpp
@@ -284,10 +284,7 @@ void emu_loop(bool reset)
 
     exiting = false;
 
-    // TODO: try to properly fix that (it causes an ICE on clang)
-    #ifndef __APPLE__
-        __builtin_setjmp(restart_after_exception);
-    #endif
+    __builtin_setjmp(restart_after_exception);
 
     while (!exiting) {
         sched_process_pending_events();

--- a/firebird.pro
+++ b/firebird.pro
@@ -34,12 +34,6 @@ QMAKE_CFLAGS_RELEASE = -O3 -flto
 QMAKE_CXXFLAGS_RELEASE = -O3 -flto
 QMAKE_LFLAGS_RELEASE = -Wl,-O3 -flto
 
-# ICE on mac with clang
-macx-clang|ios {
-    QMAKE_CFLAGS_RELEASE -= -flto
-    QMAKE_CXXFLAGS_RELEASE -= -flto
-    QMAKE_LFLAGS_RELEASE -= -Wl,-O3 -flto
-}
 
 macx {
     ICON = resources/logo.icns


### PR DESCRIPTION
It's nice because without the TLB handler (af779cb), it now doesn't crash.

The downside is that we won't see as easily which instructions could cause an issue :P